### PR TITLE
feat: Add Dependabot configuration for automatic dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"


### PR DESCRIPTION
This commit introduces a Dependabot configuration file (`.github/dependabot.yml`) to automate the process of checking for and updating Rust (Cargo) dependencies.

Dependabot will now:
- Check for outdated Cargo dependencies weekly on Mondays.
- Create pull requests for available updates.
- Use the commit message prefix "chore(deps)" for these pull requests.

This helps in keeping your project dependencies up-to-date and secure.